### PR TITLE
create pdf build pipeline

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/xu-cheng/texlive-full:20220901
+WORKDIR /doc
+RUN apk add --no-cache \
+    make=4.3-r0 \
+    && rm -rf /var/cache/apk/*
+CMD [ "/bin/sh" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "TeX Live",
+  "build": { "dockerfile": "Dockerfile" },
+  "customizations": {
+    "vscode": {
+      "extensions": ["james-yu.latex-workshop"]
+    }
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: main
+    open-pull-requests-limit: 1
+    labels:
+      - dependabot
+      - security
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: docker
+    directory: /.devcontainer
+    schedule:
+      interval: monthly
+    target-branch: main
+    open-pull-requests-limit: 1
+    labels:
+      - dependabot
+      - security

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,374 @@
+name: Build Docs
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/Design/MG/**"
+      - "docs/Design/MIS/**"
+      - "docs/DevelopmentPlan/**"
+      - "docs/HazardAnalysis/**"
+      - "docs/ProblemStatementAndGoals/**"
+      - "docs/Reflection/**"
+      - "docs/SRS/**"
+      - "docs/UserGuide/**"
+      - "docs/VnVPlan/**"
+      - "docs/VnVReport/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/Design/MG/**"
+      - "docs/Design/MIS/**"
+      - "docs/DevelopmentPlan/**"
+      - "docs/HazardAnalysis/**"
+      - "docs/ProblemStatementAndGoals/**"
+      - "docs/Reflection/**"
+      - "docs/SRS/**"
+      - "docs/UserGuide/**"
+      - "docs/VnVPlan/**"
+      - "docs/VnVReport/**"
+
+env:
+  MG_FILENAME: MG.pdf
+  MG_DIR: docs/Design/MG
+  MIS_FILENAME: MIS.pdf
+  MIS_DIR: docs/Design/MIS
+  DEVP_FILENAME: DevelopmentPlan.pdf
+  DEVP_DIR: docs/DevelopmentPlan
+  HAZA_FILENAME: HazardAnalysis.pdf
+  HAZA_DIR: docs/HazardAnalysis
+  PS_FILENAME: ProblemStatement.pdf
+  PS_DIR: docs/ProblemStatementAndGoals
+  REFL_FILENAME: Reflection.pdf
+  REFL_DIR: docs/Reflection
+  SRS_FILENAME: SRS.pdf
+  SRS_DIR: docs/SRS
+  UGDE_FILENAME: UserGuide.pdf
+  UGDE_DIR: docs/UserGuide
+  VNVP_FILENAME: VnVPlan.pdf
+  VNVP_DIR: docs/VnVPlan
+  VNVR_FILENAME: VnVReport.pdf
+  VNVR_DIR: docs/VnVReport
+
+jobs:
+
+  # Checks for which PDFs need to be rebuilt
+  changes:
+    name: 🧞 Check What Changed
+    runs-on: ubuntu-latest
+    outputs:
+      module_guide: ${{ steps.filter.outputs.module_guide }}
+      module_interface_spec: ${{ steps.filter.outputs.module_interface_spec }}
+      dev_plan: ${{ steps.filter.outputs.dev_plan }}
+      hazard_analysis: ${{ steps.filter.outputs.hazard_analysis }}
+      problem_statement: ${{ steps.filter.outputs.problem_statement }}
+      reflection: ${{ steps.filter.outputs.reflection }}
+      srs: ${{ steps.filter.outputs.srs }}
+      user_guide: ${{ steps.filter.outputs.user_guide }}
+      vnv_plan: ${{ steps.filter.outputs.vnv_plan }}
+      vnv_report: ${{ steps.filter.outputs.vnv_report }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 🧞 Check What Changed
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            module_guide:
+              - '${{ env.MG_DIR }}/**'
+            module_interface_spec:
+              - '${{ env.MIS_DIR }}/**'
+            dev_plan:
+              - '${{ env.DEVP_DIR }}/**'
+            hazard_analysis:
+              - '${{ env.HAZA_DIR }}/**'
+            problem_statement:
+              - '${{ env.PS_DIR }}/**'
+            reflection:
+              - '${{ env.REFL_DIR }}/**'
+            srs:
+              - '${{ env.SRS_DIR }}/**'
+            user_guide:
+              - '${{ env.UGDE_DIR }}/**'
+            vnv_plan:
+              - '${{ env.VNVP_DIR }}/**'
+            vnv_report:
+              - '${{ env.VNVR_DIR }}/**'
+
+  build_module_guide:
+    name: 🏗 Build Module Guide
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.module_guide == 'true' }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 👷 Build LaTeX PDF
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            apk add --update-cache make
+            cd docs
+            make MG
+
+      - name: 💾 Save LaTeX PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.MG_FILENAME }}
+          path: "${{ env.MG_DIR }}/${{ env.MG_FILENAME }}"
+
+  build_module_interface_spec:
+    name: 🏗 Build Module Interface Specification
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.module_interface_spec == 'true' }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 👷 Build LaTeX PDF
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            apk add --update-cache make
+            cd docs
+            make MIS
+
+      - name: 💾 Save LaTeX PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.MIS_FILENAME }}
+          path: "${{ env.MIS_DIR }}/${{ env.MIS_FILENAME }}"
+
+  build_dev_plan:
+    name: 🏗 Build Development Plan
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.dev_plan == 'true' }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 👷 Build LaTeX PDF
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            apk add --update-cache make
+            cd docs
+            make DevP
+
+      - name: 💾 Save LaTeX PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.DEVP_FILENAME }}
+          path: "${{ env.DEVP_DIR }}/${{ env.DEVP_FILENAME }}"
+
+  build_hazard_analysis:
+    name: 🏗 Build Hazard Analysis
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.hazard_analysis == 'true' }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 👷 Build LaTeX PDF
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            apk add --update-cache make
+            cd docs
+            make HazA
+
+      - name: 💾 Save LaTeX PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.HAZA_FILENAME }}
+          path: "${{ env.HAZA_DIR }}/${{ env.HAZA_FILENAME }}"
+
+  build_problem_statement:
+    name: 🏗 Build Problem Statement & Goals
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.problem_statement == 'true' }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 👷 Build LaTeX PDF
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            apk add --update-cache make
+            cd docs
+            make PS
+
+      - name: 💾 Save LaTeX PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.PS_FILENAME }}
+          path: "${{ env.PS_DIR }}/${{ env.PS_FILENAME }}"
+
+  build_reflection:
+    name: 🏗 Build Reflection Report
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.reflection == 'true' }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 👷 Build LaTeX PDF
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            apk add --update-cache make
+            cd docs
+            make Refl
+
+      - name: 💾 Save LaTeX PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.REFL_FILENAME }}
+          path: "${{ env.REFL_DIR }}/${{ env.REFL_FILENAME }}"
+
+  build_srs:
+    name: 🏗 Build Software Requirements Specification
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.srs == 'true' }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 👷 Build LaTeX PDF
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            apk add --update-cache make
+            cd docs
+            make SRS
+
+      - name: 💾 Save LaTeX PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.SRS_FILENAME }}
+          path: "${{ env.SRS_DIR }}/${{ env.SRS_FILENAME }}"
+
+  build_user_guide:
+    name: 🏗 Build User Guide
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.user_guide == 'true' }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 👷 Build LaTeX PDF
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            apk add --update-cache make
+            cd docs
+            make UGde
+
+      - name: 💾 Save LaTeX PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.UGDE_FILENAME }}
+          path: "${{ env.UGDE_DIR }}/${{ env.UGDE_FILENAME }}"
+
+  build_vnv_plan:
+    name: 🏗 Build System Verification and Validation Plan
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.vnv_plan == 'true' }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 👷 Build LaTeX PDF
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            apk add --update-cache make
+            cd docs
+            make VnVP
+
+      - name: 💾 Save LaTeX PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.VNVP_FILENAME }}
+          path: "${{ env.VNVP_DIR }}/${{ env.VNVP_FILENAME }}"
+
+  build_vnv_report:
+    name: 🏗 Build System Verification and Validation Report
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.vnv_report == 'true' }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 👷 Build LaTeX PDF
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            apk add --update-cache make
+            cd docs
+            make VnVR
+
+      - name: 💾 Save LaTeX PDF
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.VNVR_FILENAME }}
+          path: "${{ env.VNVR_DIR }}/${{ env.VNVR_FILENAME }}"
+
+  publish_pdfs:
+    name: 🚀 Publish Built LaTeX PDFs
+    needs:
+      - changes
+      - build_module_guide
+      - build_module_interface_spec
+      - build_dev_plan
+      - build_hazard_analysis
+      - build_problem_statement
+      - build_reflection
+      - build_srs
+      - build_user_guide
+      - build_vnv_plan
+      - build_vnv_report
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && always() # runs even if job cancelled
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: 🛎 Checkout
+        uses: actions/checkout@v3
+
+      - name: 📥 Download PDFs
+        uses: actions/download-artifact@v3.0.0
+
+      - name: 🚧 Move PDFs To Correct Directory
+        run: |
+          [ ! -e "$MG_FILENAME/$MG_FILENAME" ]      || mv -v "$MG_FILENAME/$MG_FILENAME" "$MG_DIR/$MG_FILENAME"
+          [ ! -e "$MIS_FILENAME/$MIS_FILENAME" ]    || mv -v "$MIS_FILENAME/$MIS_FILENAME" "$MIS_DIR/$MIS_FILENAME"
+          [ ! -e "$DEVP_FILENAME/$DEVP_FILENAME" ]  || mv -v "$DEVP_FILENAME/$DEVP_FILENAME" "$DEVP_DIR/$DEVP_FILENAME"
+          [ ! -e "$HAZA_FILENAME/$HAZA_FILENAME" ]  || mv -v "$HAZA_FILENAME/$HAZA_FILENAME" "$HAZA_DIR/$HAZA_FILENAME"
+          [ ! -e "$PS_FILENAME/$PS_FILENAME" ]      || mv -v "$PS_FILENAME/$PS_FILENAME" "$PS_DIR/$PS_FILENAME"
+          [ ! -e "$REFL_FILENAME/$REFL_FILENAME" ]  || mv -v "$REFL_FILENAME/$REFL_FILENAME" "$REFL_DIR/$REFL_FILENAME"
+          [ ! -e "$SRS_FILENAME/$SRS_FILENAME" ]    || mv -v "$SRS_FILENAME/$SRS_FILENAME" "$SRS_DIR/$SRS_FILENAME"
+          [ ! -e "$UGDE_FILENAME/$UGDE_FILENAME" ]  || mv -v "$UGDE_FILENAME/$UGDE_FILENAME" "$UGDE_DIR/$UGDE_FILENAME"
+          [ ! -e "$VNVP_FILENAME/$VNVP_FILENAME" ]  || mv -v "$VNVP_FILENAME/$VNVP_FILENAME" "$VNVP_DIR/$VNVP_FILENAME"
+          [ ! -e "$VNVR_FILENAME/$VNVR_FILENAME" ]  || mv -v "$VNVR_FILENAME/$VNVR_FILENAME" "$VNVR_DIR/$VNVR_FILENAME"
+
+      - name: 🚀 Add & Commit
+        uses: EndBug/add-and-commit@v9.1.0
+        with:
+          default_author: github_actions
+          add: "'*.pdf' --force"
+          pathspec_error_handling: exitAtEnd
+          message: "Built PDFs via Github Actions"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,32 +4,18 @@ on:
     branches:
       - main
     paths:
-      - "docs/Design/MG/**"
-      - "docs/Design/MIS/**"
-      - "docs/DevelopmentPlan/**"
-      - "docs/HazardAnalysis/**"
-      - "docs/ProblemStatementAndGoals/**"
-      - "docs/Reflection/**"
-      - "docs/SRS/**"
-      - "docs/UserGuide/**"
-      - "docs/VnVPlan/**"
-      - "docs/VnVReport/**"
+    - docs/**
+    - refs/References.bib
   push:
     branches:
       - main
     paths:
-      - "docs/Design/MG/**"
-      - "docs/Design/MIS/**"
-      - "docs/DevelopmentPlan/**"
-      - "docs/HazardAnalysis/**"
-      - "docs/ProblemStatementAndGoals/**"
-      - "docs/Reflection/**"
-      - "docs/SRS/**"
-      - "docs/UserGuide/**"
-      - "docs/VnVPlan/**"
-      - "docs/VnVReport/**"
+    - docs/**
+    - refs/References.bib
 
 env:
+  COMMENTS_PATH: docs/Comments.tex
+  COMMON_PATH: docs/Common.tex
   MG_FILENAME: MG.pdf
   MG_DIR: docs/Design/MG
   MIS_FILENAME: MIS.pdf
@@ -40,6 +26,7 @@ env:
   HAZA_DIR: docs/HazardAnalysis
   PS_FILENAME: ProblemStatement.pdf
   PS_DIR: docs/ProblemStatementAndGoals
+  REFERENCES_PATH: refs/References.bib
   REFL_FILENAME: Reflection.pdf
   REFL_DIR: docs/Reflection
   SRS_FILENAME: SRS.pdf
@@ -77,25 +64,41 @@ jobs:
         id: filter
         with:
           filters: |
+            common: &common
+              - '${{ env.COMMENTS_PATH }}'
+              - '${{ env.COMMON_PATH }}'
+            references: &references
+              - '${{ env.REFERENCES_PATH }}'
             module_guide:
+              - *common
               - '${{ env.MG_DIR }}/**'
             module_interface_spec:
+              - *common
               - '${{ env.MIS_DIR }}/**'
             dev_plan:
+              - *common
               - '${{ env.DEVP_DIR }}/**'
             hazard_analysis:
+              - *common
               - '${{ env.HAZA_DIR }}/**'
             problem_statement:
+              - *common
               - '${{ env.PS_DIR }}/**'
             reflection:
+              - *common
               - '${{ env.REFL_DIR }}/**'
             srs:
+              - *common
+              - *references
               - '${{ env.SRS_DIR }}/**'
             user_guide:
+              - *common
               - '${{ env.UGDE_DIR }}/**'
             vnv_plan:
+              - *common
               - '${{ env.VNVP_DIR }}/**'
             vnv_report:
+              - *common
               - '${{ env.VNVR_DIR }}/**'
 
   build_module_guide:


### PR DESCRIPTION
Close #4 

- Enables Dependabot for tracking the `.devcontainer/Dockerfile` and Github Actions plugins
- Create a pipeline for building PDFs
  - Will only build the PDFs for those that have changed
  - Will commit the PDFs back into the repo if this is triggered by a push to `main`
  - Will run on PRs, but not commit back to repo
  - Builds can be found as artifacts on the pipeline runs
  - Will rebuild all docs if `docs/Comments.tex` or `docs/Common.tex` are changed
  - Will rebuild SRS if `refs/References.bib` is changed
- Add `.devcontainer`
  - Using the `.devcontainer` will allow you to build the PDFs locally without needing a LaTeX compiler installed
    - Uses Docker and [`ms-vscode-remote.remote-containers`](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) VS Code Extension